### PR TITLE
Fix AI conversation schema and daily commitment filtering

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -39,7 +39,7 @@ import {
   type InsertCoachingInsight
 } from "@shared/schema";
 import { db } from "./db";
-import { eq, and, desc } from "drizzle-orm";
+import { eq, and, desc, gte } from "drizzle-orm";
 
 export interface IStorage {
   getUser(id: string): Promise<User | undefined>;
@@ -510,7 +510,8 @@ export class DatabaseStorage implements IStorage {
       .from(dailyCommitments)
       .where(and(
         eq(dailyCommitments.userId, userId),
-        // Use comparison for date strings in YYYY-MM-DD format
+        // Include commitments on or after the cutoff date (dates are stored as YYYY-MM-DD strings)
+        gte(dailyCommitments.date, cutoffString)
       ))
       .orderBy(desc(dailyCommitments.date));
   }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -77,7 +77,9 @@ export const aiConversations = pgTable("ai_conversations", {
   sessionId: varchar("session_id").notNull(), // Groups related messages
   messages: jsonb("messages").notNull(), // Array of {role: 'user'|'assistant', content: string, timestamp: Date}
   context: jsonb("context"), // Exercise context, chapter info, etc.
-  type: varchar("type", { enum: ["therapeutic_guidance", "reflection_support", "general_chat"] }).notNull(),
+  type: varchar("type", {
+    enum: ["therapeutic_guidance", "crisis_support", "reflection", "goal_setting"],
+  }).notNull(),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),
 });


### PR DESCRIPTION
## Summary
- align the `ai_conversations` table enum with the conversation types used by the API
- ensure historical daily commitment queries only return entries within the requested window

## Testing
- npm run check *(fails: existing TypeScript type errors in client/src/pages/PostAssessment.tsx and server/routes.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d046cf9ac083279cbbea3efcb282c8